### PR TITLE
v0.0.2 version bump & changelog update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## v0.0.2 - 2023-02-03 - Now with more PTR values
+
+* Support for multi-value PTRs
+
 ## v0.0.1 - 2022-01-07 - Moving
 
 #### Nothworthy Changes

--- a/octodns_edgedns/__init__.py
+++ b/octodns_edgedns/__init__.py
@@ -12,7 +12,7 @@ from octodns.record import Record
 from octodns.provider import ProviderException
 from octodns.provider.base import BaseProvider
 
-__VERSION__ = '0.0.1'
+__VERSION__ = '0.0.2'
 
 
 class AkamaiClientNotFound(ProviderException):


### PR DESCRIPTION
## v0.0.2 - 2023-02-03 - Now with more PTR values

* Support for multi-value PTRs

/cc https://github.com/octodns/octodns-edgedns/pull/12 @hightoxicity