### PR TITLE
Manage CAA records

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ The contract_id paramater is optional, and only required for creating a new zone
 
 #### Records
 
-AkamaiProvider supports A, AAAA, CNAME, MX, NAPTR, NS, PTR, SPF, SRV, SSHFP, and TXT.
+AkamaiProvider supports A, AAAA, CAA, CNAME, MX, NAPTR, NS, PTR, SPF, SRV, SSHFP, and TXT.
 
 #### Dynamic
 

--- a/octodns_edgedns/__init__.py
+++ b/octodns_edgedns/__init__.py
@@ -129,6 +129,7 @@ class AkamaiProvider(BaseProvider):
         (
             'A',
             'AAAA',
+            'CAA',
             'CNAME',
             'MX',
             'NAPTR',
@@ -301,6 +302,13 @@ class AkamaiProvider(BaseProvider):
     _data_for_PTR = _data_for_multiple
     _data_for_SPF = _data_for_multiple
 
+    def _data_for_CAA(self, _type, records):
+        values = []
+        for r in records['rdata']:
+            flags, tag, value = r.split(" ", 2)
+            values.append({'flags': flags, 'tag': tag, 'value': value})
+        return {'ttl': records['ttl'], 'type': _type, 'values': values}
+
     def _data_for_CNAME(self, _type, records):
         value = records['rdata'][0]
         if value[-1] != '.':
@@ -381,6 +389,17 @@ class AkamaiProvider(BaseProvider):
     _params_for_PTR = _params_for_multiple
 
     _params_for_CNAME = _params_for_single
+
+    def _params_for_CAA(self, values):
+        rdata = []
+
+        for r in values:
+            flags = r['flags']
+            tag = r['tag']
+            value = r['value']
+            rdata.append(f'{flags} {tag} {value}')
+
+        return rdata
 
     def _params_for_MX(self, values):
         rdata = []

--- a/tests/fixtures/edgedns-records.json
+++ b/tests/fixtures/edgedns-records.json
@@ -46,6 +46,14 @@
         },
         {
             "rdata": [
+                "0 issue ca.unit.tests"
+            ],
+            "type": "CAA",
+            "name": "unit.tests",
+            "ttl": 3600
+        },
+        {
+            "rdata": [
                 "1.2.3.4",
                 "1.2.3.5"
             ],
@@ -167,7 +175,7 @@
         }
     ],
     "metadata": {
-        "totalElements": 18,
+        "totalElements": 19,
         "showAll": true
     }
 }

--- a/tests/test_octodns_provider_edgedns.py
+++ b/tests/test_octodns_provider_edgedns.py
@@ -79,14 +79,14 @@ class TestEdgeDnsProvider(TestCase):
 
             zone = Zone('unit.tests.', [])
             provider.populate(zone)
-            self.assertEqual(18, len(zone.records))
+            self.assertEqual(19, len(zone.records))
             changes = self.expected.changes(zone, provider)
             self.assertEqual(0, len(changes))
 
         # 2nd populate makes no network calls/all from cache
         again = Zone('unit.tests.', [])
         provider.populate(again)
-        self.assertEqual(18, len(again.records))
+        self.assertEqual(19, len(again.records))
 
         # bust the cache
         del provider._zone_records[zone.name]
@@ -114,7 +114,7 @@ class TestEdgeDnsProvider(TestCase):
             mock.delete(ANY, status_code=204)
 
             changes = provider.apply(plan)
-            self.assertEqual(31, changes)
+            self.assertEqual(32, changes)
 
         # Test against a zone that doesn't exist yet
         with requests_mock() as mock:
@@ -127,7 +127,7 @@ class TestEdgeDnsProvider(TestCase):
             mock.delete(ANY, status_code=204)
 
             changes = provider.apply(plan)
-            self.assertEqual(16, changes)
+            self.assertEqual(17, changes)
 
         # Test against a zone that doesn't exist yet, but gid not provided
         with requests_mock() as mock:
@@ -148,7 +148,7 @@ class TestEdgeDnsProvider(TestCase):
             mock.delete(ANY, status_code=204)
 
             changes = provider.apply(plan)
-            self.assertEqual(16, changes)
+            self.assertEqual(17, changes)
 
         # Test against a zone that doesn't exist, but cid not provided
 


### PR DESCRIPTION
Add CAA record type support to the edgedns octodns plugin