### PR TITLE
anchor search for version number in script/release

### DIFF
--- a/script/release
+++ b/script/release
@@ -20,7 +20,7 @@ fi
 # Set so that setup.py will create a public release style version number
 export OCTODNS_RELEASE=1
 
-VERSION="$(grep __VERSION__ "$ROOT/octodns_edgedns/__init__.py" | sed -e "s/.* = '//" -e "s/'$//")"
+VERSION="$(grep "^__VERSION__" "$ROOT/octodns_edgedns/__init__.py" | head -n 1 | sed -e "s/.* = '//" -e "s/'$//")"
 
 git tag -s "v$VERSION" -m "Release $VERSION"
 git push origin "v$VERSION"


### PR DESCRIPTION
The new user-agent stuff has caused problems for the naive version number search:

```console
coho:octodns-edgedns ross$ ./script/release
fatal: 'vfrom octodns import __VERSION__ as octodns_version
0.0.3
                'User-Agent': f'octodns/{octodns_version} octodns-edgedns/{__VERSION__}' is not a valid tag name.
```

/cc https://github.com/octodns/octodns-edgedns/pull/17