### PR TITLE
fix: introduce SOA and NS record init for new zones

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## v0.0.3 - 2024-01-27 - Primary Zone Creation
+
+* Support for creation of primary zones.
+  Includes automatic creation of NS record set,
+  and SOA record for zones that do not exist.
+* Support for comments, i.e. zone descriptions.
+
 ## v0.0.2 - 2023-03-16 - CAA has arrived
 
 * Support for CAA records has been added

--- a/octodns_edgedns/__init__.py
+++ b/octodns_edgedns/__init__.py
@@ -1,7 +1,6 @@
 #
 #
 #
-
 from collections import defaultdict
 from logging import getLogger
 from urllib.parse import urljoin
@@ -36,7 +35,9 @@ class AkamaiClient(object):
 
     '''
 
-    def __init__(self, client_secret, host, access_token, client_token):
+    def __init__(
+        self, client_secret, host, access_token, client_token, comment
+    ):
         self.base = "https://" + host + "/config-dns/v2/"
 
         sess = Session()
@@ -51,6 +52,7 @@ class AkamaiClient(object):
             access_token=access_token,
         )
         self._sess = sess
+        self.comment = comment
 
     def _request(self, method, path, params=None, data=None, v1=False):
         url = urljoin(self.base, path)
@@ -96,12 +98,8 @@ class AkamaiClient(object):
 
         return result
 
-    def zone_changelist_create(self, zone, overwrite=False):
+    def zone_changelist_create(self, zone):
         path = f'changelists?zone={zone}'
-
-        if overwrite:
-            path += '&overwrite=stale'
-
         result = self._request('POST', path, data={})
 
         return result
@@ -109,7 +107,9 @@ class AkamaiClient(object):
     def zone_changelist_submit(self, zone):
         path = f'changelists/{zone}/submit'
 
-        result = self._request('POST', path, data={})
+        result = self._request(
+            'POST', path, data={}, params={"comment": self.comment}
+        )
 
         return result
 
@@ -169,6 +169,7 @@ class AkamaiProvider(BaseProvider):
         client_token,
         contract_id=None,
         gid=None,
+        comment=None,
         *args,
         **kwargs,
     ):
@@ -177,7 +178,7 @@ class AkamaiProvider(BaseProvider):
         super().__init__(id, *args, **kwargs)
 
         self._dns_client = AkamaiClient(
-            client_secret, host, access_token, client_token
+            client_secret, host, access_token, client_token, comment
         )
 
         self._zone_records = {}
@@ -249,7 +250,7 @@ class AkamaiProvider(BaseProvider):
             self.log.info(
                 "zone created, generating SOA and NS records (required)."
             )
-            self._dns_client.zone_changelist_create(zone_name, True)
+            self._dns_client.zone_changelist_create(zone_name)
             self._dns_client.zone_changelist_submit(zone_name)
 
         for change in changes:

--- a/octodns_edgedns/__init__.py
+++ b/octodns_edgedns/__init__.py
@@ -96,6 +96,23 @@ class AkamaiClient(object):
 
         return result
 
+    def zone_changelist_create(self, zone, overwrite=False):
+        path = f'changelists?zone={zone}'
+
+        if overwrite:
+            path += '&overwrite=stale'
+
+        result = self._request('POST', path, data={})
+
+        return result
+
+    def zone_changelist_submit(self, zone):
+        path = f'changelists/{zone}/submit'
+
+        result = self._request('POST', path, data={})
+
+        return result
+
     def zone_recordset_get(
         self,
         zone,
@@ -229,6 +246,11 @@ class AkamaiProvider(BaseProvider):
             self.log.info("zone not found, creating zone")
             params = self._build_zone_config(zone_name)
             self._dns_client.zone_create(self._contractId, params, self._gid)
+            self.log.info(
+                "zone created, generating SOA and NS records (required)."
+            )
+            self._dns_client.zone_changelist_create(zone_name, True)
+            self._dns_client.zone_changelist_submit(zone_name)
 
         for change in changes:
             class_name = change.__class__.__name__

--- a/tests/test_octodns_provider_edgedns.py
+++ b/tests/test_octodns_provider_edgedns.py
@@ -100,6 +100,7 @@ class TestEdgeDnsProvider(TestCase):
             "ctok",
             "cid",
             "gid",
+            "Managed by OctoDNS.",
             strict_supports=False,
         )
 

--- a/tests/test_octodns_provider_edgedns.py
+++ b/tests/test_octodns_provider_edgedns.py
@@ -4,6 +4,7 @@
 
 from os.path import dirname, join
 from unittest import TestCase
+from unittest.mock import patch
 
 from requests import HTTPError
 from requests_mock import ANY
@@ -100,7 +101,6 @@ class TestEdgeDnsProvider(TestCase):
             "ctok",
             "cid",
             "gid",
-            "Managed by OctoDNS.",
             strict_supports=False,
         )
 
@@ -169,3 +169,54 @@ class TestEdgeDnsProvider(TestCase):
             except NameError as e:
                 expected = "contractId not specified to create zone"
                 self.assertEqual(str(e), expected)
+
+    def test_zone_changelist_submit_with_comment(self):
+        comment = "Managed by OctoDNS."
+        provider = AkamaiProvider(
+            "test",
+            "s",
+            "akam.com",
+            "atok",
+            "ctok",
+            "cid",
+            "gid",
+            comment,
+            strict_supports=False,
+        )
+
+        with patch.object(provider._dns_client, '_request') as mock_request:
+            provider._dns_client.zone_changelist_submit("foo.bar.test.com")
+
+            mock_request.assert_called_once_with(
+                'POST',
+                'changelists/foo.bar.test.com/submit',
+                data={},
+                params={"comment": comment},
+            )
+
+    def test_apply_method_calls_zone_changelist_submit(self):
+        comment = "Managed by OctoDNS."
+        provider = AkamaiProvider(
+            "test",
+            "s",
+            "akam.com",
+            "atok",
+            "ctok",
+            "cid",
+            "gid",
+            comment,
+            strict_supports=False,
+        )
+
+        with requests_mock() as mock:
+            mock.get(ANY, status_code=404)
+            mock.post(ANY, status_code=201)
+            mock.put(ANY, status_code=200)
+            mock.delete(ANY, status_code=204)
+
+            with patch.object(
+                provider._dns_client, 'zone_changelist_submit'
+            ) as mock_zone_submit:
+                plan = provider.plan(self.expected)
+                provider._apply(plan)
+                mock_zone_submit.assert_called_once()


### PR DESCRIPTION
Akamai requires that, before any resource records can be added to a zone, SOA and NS records are created at zone apex.

This means when creating a new DNS zone via OctoDNS, you will not be able to configure any resource records on it.

SOA is not supported. NS records at root _are_ supported, but with tricks.

This commit adds the steps laid out in Akamai documentation to generate a default changelist and submit it.

@ross perhaps you have time to take a look at this? I'm happy to use my fork, but this might be helpful for others looking for zone creation / deletion in Akamai.