### PR TITLE
Rel 0 0 4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
   and SOA record for zones that do not exist.
 * Support for comments, i.e. zone descriptions.
 
-## v0.0.2 - 2023-03-16 - CAA has arrived
+## v0.0.3 - 2023-03-16 - CAA has arrived
 
 * Support for CAA records has been added
 * Set a user-agent on outgoing http requests

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## v0.0.3 - 2024-01-27 - Primary Zone Creation
+## v0.0.4 - 2024-01-27 - Primary Zone Creation
 
 * Support for creation of primary zones.
   Includes automatic creation of NS record set,

--- a/octodns_edgedns/__init__.py
+++ b/octodns_edgedns/__init__.py
@@ -14,7 +14,7 @@ from octodns.provider.base import BaseProvider
 from octodns.record import Record
 
 # TODO: remove __VERSION__ with the next major version release
-__version__ = __VERSION__ = '0.0.3'
+__version__ = __VERSION__ = '0.0.4'
 
 
 class AkamaiClientNotFound(ProviderException):


### PR DESCRIPTION
## v0.0.4 - 2024-01-27 - Primary Zone Creation

* Support for creation of primary zones.
  Includes automatic creation of NS record set,
  and SOA record for zones that do not exist.
* Support for comments, i.e. zone descriptions.

/cc https://github.com/octodns/octodns-edgedns/pull/17 which had the wrong version number in the changelog, this fixes it
/cc @patrickellis @istr 