### PR TITLE
Version 1.1.0 bump & changelog update

### DIFF
--- a/.changelog/05f3b5dc965240e7a07f71522e390fd9.md
+++ b/.changelog/05f3b5dc965240e7a07f71522e390fd9.md
@@ -1,4 +1,0 @@
----
-type: patch
----
-Use new [changelet](https://github.com/octodns/changelet) tooling

--- a/.changelog/0c766cb99c8a419aa8af6396b7ee56aa.md
+++ b/.changelog/0c766cb99c8a419aa8af6396b7ee56aa.md
@@ -1,4 +1,0 @@
----
-type: none
----
-Run changelog check during pre-commit

--- a/.changelog/0e66ec85fd324cbcba1389abaf953394.md
+++ b/.changelog/0e66ec85fd324cbcba1389abaf953394.md
@@ -1,4 +1,0 @@
----
-type: none
----
-Update requirements

--- a/.changelog/1648f8f204eb41a3983383493f629103.md
+++ b/.changelog/1648f8f204eb41a3983383493f629103.md
@@ -1,4 +1,0 @@
----
-type: none
----
-Update requirements

--- a/.changelog/3682b035ff104583bfa08a626779d235.md
+++ b/.changelog/3682b035ff104583bfa08a626779d235.md
@@ -1,4 +1,0 @@
----
-type: none
----
-Update requirements.txt

--- a/.changelog/3eb12ecb2da24426b02035b43bfa9a6d.md
+++ b/.changelog/3eb12ecb2da24426b02035b43bfa9a6d.md
@@ -1,5 +1,0 @@
----
-type: minor
----
-
-Add support for TLSA, DS, HTTPS, LOC, and SVCB records. Fix CAA record parsing to properly handle quoted values.

--- a/.changelog/41bc3f8da3c84ca9a734d0be96c589c5.md
+++ b/.changelog/41bc3f8da3c84ca9a734d0be96c589c5.md
@@ -1,4 +1,0 @@
----
-type: none
----
-Update scripts to use common.sh

--- a/.changelog/57f3d8d7783a46989aaae5ceec7b4494.md
+++ b/.changelog/57f3d8d7783a46989aaae5ceec7b4494.md
@@ -1,4 +1,0 @@
----
-type: none
----
-Use script/common.sh in script/update-requirements

--- a/.changelog/7d759d784cdd44abbade5eec152a729b.md
+++ b/.changelog/7d759d784cdd44abbade5eec152a729b.md
@@ -1,4 +1,0 @@
----
-type: none
----
-Update requirements

--- a/.changelog/7f722301e34140f7bbf0b4126709342d.md
+++ b/.changelog/7f722301e34140f7bbf0b4126709342d.md
@@ -1,4 +1,0 @@
----
-type: none
----
-Add JSON coverage report format

--- a/.changelog/8d5ac9f8740a4cdd9dde916a17e8ffef.md
+++ b/.changelog/8d5ac9f8740a4cdd9dde916a17e8ffef.md
@@ -1,4 +1,0 @@
----
-type: none
----
-Switch to proviso for requirements.txt management

--- a/.changelog/d3649c62c26f437ba4b7af5d680b7def.md
+++ b/.changelog/d3649c62c26f437ba4b7af5d680b7def.md
@@ -1,4 +1,0 @@
----
-type: none
----
-Update requirements*.txt

--- a/.changelog/dc93ad99de944416af25230b2e4ac74f.md
+++ b/.changelog/dc93ad99de944416af25230b2e4ac74f.md
@@ -1,4 +1,0 @@
----
-type: none
----
-Pull in the latest template changes

--- a/.changelog/f7f47230b709484b8348493015570534.md
+++ b/.changelog/f7f47230b709484b8348493015570534.md
@@ -1,4 +1,0 @@
----
-type: none
----
-Update requirements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 1.1.0 - 2026-04-03
+
+Minor:
+* Add support for TLSA, DS, HTTPS, LOC, and SVCB records. Fix CAA record parsing to properly handle quoted values. - [#63](https://github.com/octodns/octodns-edgedns/pull/63)
+
+Patch:
+* Use new [changelet](https://github.com/octodns/changelet) tooling - [#55](https://github.com/octodns/octodns-edgedns/pull/55)
+
 ## v1.0.0 - 2024-04-29 - Long overdue 1.0
 
 Noteworthy Changes:

--- a/octodns_edgedns/__init__.py
+++ b/octodns_edgedns/__init__.py
@@ -14,7 +14,7 @@ from octodns.provider.base import BaseProvider
 from octodns.record import Record
 
 # TODO: remove __VERSION__ with the next major version release
-__version__ = __VERSION__ = '1.0.0'
+__version__ = __VERSION__ = '1.1.0'
 
 
 class AkamaiClientNotFound(ProviderException):


### PR DESCRIPTION
## 1.1.0 - 2026-04-03

Minor:
* Add support for TLSA, DS, HTTPS, LOC, and SVCB records. Fix CAA record parsing to properly handle quoted values. - [#63](https://github.com/octodns/octodns-edgedns/pull/63)

Patch:
* Use new [changelet](https://github.com/octodns/changelet) tooling - [#55](https://github.com/octodns/octodns-edgedns/pull/55)

