### PR TITLE
Explicit non-escaped semicolons for YamlProvider

### DIFF
--- a/.changelog/b547a544b5c04e2c9e767894c36f20c3.md
+++ b/.changelog/b547a544b5c04e2c9e767894c36f20c3.md
@@ -1,0 +1,4 @@
+---
+type: none
+---
+Explicit non-escaped semicolons for YamlProvider

--- a/tests/config/unit.tests.yaml
+++ b/tests/config/unit.tests.yaml
@@ -200,7 +200,7 @@ txt:
   values:
     - Bah bah black sheep
     - have you any wool.
-    - 'v=DKIM1\;k=rsa\;s=email\;h=sha256\;p=A/kinda+of/long/string+with+numb3rs'
+    - 'v=DKIM1;k=rsa;s=email;h=sha256;p=A/kinda+of/long/string+with+numb3rs'
 urlfwd:
   ttl: 300
   type: URLFWD

--- a/tests/test_octodns_provider_edgedns.py
+++ b/tests/test_octodns_provider_edgedns.py
@@ -19,7 +19,9 @@ from octodns_edgedns import AkamaiProvider
 
 class TestEdgeDnsProvider(TestCase):
     expected = Zone('unit.tests.', [])
-    source = YamlProvider('test', join(dirname(__file__), 'config'))
+    source = YamlProvider(
+        'test', join(dirname(__file__), 'config'), escaped_semicolons=False
+    )
     source.populate(expected)
 
     # Our test suite differs a bit, add our NS and remove the simple one


### PR DESCRIPTION
YamlProvider is going to default to escaped_semicolons=False in 2.x, until then we'll explicitly ask for it to get tests happy w/o the deprecated warning.

/cc https://github.com/octodns/octodns/pull/1419